### PR TITLE
fix Documentation url on status page

### DIFF
--- a/lib/views/status.slim
+++ b/lib/views/status.slim
@@ -38,4 +38,4 @@ p
   p
     a href="/register" Get an OAuth key
 p
-  a href="github.com/Mic92/github-tags" Documentation
+  a href="//github.com/Mic92/github-tags" Documentation


### PR DESCRIPTION
Before, it would try to link you to `<APP_NAME>.herokuapp.com/github.com/Mic92/github-tags`
Now it sends you correctly to [github.com/Mic92/github-tags](http://github.com/Mic92/github-tags)
